### PR TITLE
Berechtigungs-Tool: op perms (#19)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,10 +35,17 @@ search.py       → Query-Parsing: ID / Worte / key=value Filter → OpenProject
 tui/app.py      → Textual Root-App, AppState-Enum (SELECTOR/DETAIL/REVIEW/APPLYING)
 tui/*.py        → Textual Screens und Modals (Screen-Stack)
 api.py          → httpx Async-Client für OpenProject v3 REST API
-models.py       → Pydantic-Modelle, HAL-JSON-Parsing (WorkPackage, User, Status, …)
+models.py       → Pydantic-Modelle, HAL-JSON-Parsing (WorkPackage, User, Status, Role, Membership, …)
 config.py       → TOML-Config (XDG: ~/.config/openproject-tool/config.toml), tomlkit
 queue.py        → OperationQueue: PendingOperations sammeln, mergen, batch-applyen
+perms.py        → Reine Berechtigungslogik (Source-Set-Rekonstruktion, Hierarchie, Diff/Propagation)
+perms_queue.py  → PermissionQueue: geplante additive Mitgliedschaften sammeln
+tui/perms_*.py  → `op perms`-Modus (eigene PermsApp: Projektbaum, Detail, Review, Applying)
 ```
+
+### `op perms` — Berechtigungs-Tool
+
+Eigener Modus (`op perms [projekt]`) mit eigener `PermsApp` (kein Task-State). Zeigt Projekt-Berechtigungen **gruppen-/benutzer-zentriert**: Da die v3-API keinen `inherited_from`-Marker hat, wird das **Source-Set** mengenbasiert rekonstruiert (Gruppen + Direkt-User; via Gruppe sichtbare User werden unter der Gruppe eingeklappt, siehe `perms.build_source_set`). Mitgliedschaften werden **live** geladen (nicht aus dem `[remote.*]`-Cache). Funktionen: `f` gleicht den **gesamten Teilbaum** eines Oberprojekts an (`plan_propagation`), `c` überträgt Berechtigungen von einem anderen Projekt (`plan_transfer`) — beides **additiv** (nie entfernen). Geplante Änderungen werden gesammelt (`PermissionQueue`), per `g` reviewed und angewendet (`create_membership`/`update_membership_roles`).
 
 ### Datenfluss
 
@@ -75,6 +82,9 @@ queue.py        → OperationQueue: PendingOperations sammeln, mergen, batch-app
 | ProjectFilterScreen | `tui/project_filter_screen.py` | Hierarchie-aware, persistiert in Config |
 | ReviewScreen | `tui/review_screen.py` | Batch-Review vor Apply |
 | ApplyingScreen | `tui/applying_screen.py` | Batch-PATCH-Ausführung |
+| PermsProjectsScreen | `tui/perms_projects_screen.py` | `op perms`-Root: Projektbaum mit Mismatch-Flag (`▲`); Enter Detail, `c` Übertragen, `f` Teilbaum angleichen, `g` Review, `r` Neu laden, `q` Quit |
+| PermsDetailScreen | `tui/perms_detail_screen.py` | Gruppen (mit eingeklappten Mitgliedern) + Direkt-User eines Projekts |
+| PermsReviewScreen / PermsApplyingScreen | `tui/perms_review_screen.py`, `tui/perms_applying_screen.py` | Review (`d` entfernen, `g` anwenden) + Batch-Ausführung der Mitgliedschaften |
 
 ### Date-Shortcuts (UpdateModal)
 

--- a/src/op/api.py
+++ b/src/op/api.py
@@ -13,8 +13,10 @@ from op.models import (
     Activity,
     CustomField,
     Group,
+    Membership,
     Priority,
     Project,
+    Role,
     Status,
     User,
     WorkPackage,
@@ -90,6 +92,67 @@ class OpenProjectClient:
     async def get_groups(self) -> list[Group]:
         elements = await self._get_collection('/groups')
         return [Group.from_api(e) for e in elements]
+
+    async def get_roles(self) -> list[Role]:
+        elements = await self._get_collection('/roles')
+        return [Role.from_api(e) for e in elements]
+
+    # --- memberships ------------------------------------------------------
+
+    async def get_memberships(self, project_id: int) -> list[Membership]:
+        """All project memberships for one project (users AND groups, incl. the
+        per-user entries OpenProject materialises from group memberships)."""
+        filters = [{'project': {'operator': '=', 'values': [str(project_id)]}}]
+        params = {'filters': json.dumps(filters), 'pageSize': str(_DEFAULT_PAGE_SIZE)}
+        data = await self._request('GET', '/memberships', params=params)
+        elements = list(data['_embedded']['elements'])
+        total = data.get('total', len(elements))
+        if total > len(elements):
+            pages = math.ceil(total / _DEFAULT_PAGE_SIZE)
+            extra = await asyncio.gather(*(
+                self._request('GET', '/memberships', params={
+                    'filters': json.dumps(filters),
+                    'pageSize': str(_DEFAULT_PAGE_SIZE),
+                    'offset': str(p),
+                })
+                for p in range(2, pages + 1)
+            ))
+            for d in extra:
+                elements.extend(d['_embedded']['elements'])
+        return [Membership.from_api(e) for e in elements]
+
+    async def get_group_members(self, group_id: int) -> list[int]:
+        """Return the user ids belonging to a group (from the group's _links.members)."""
+        data = await self._request('GET', f'/groups/{group_id}')
+        return Group.from_api(data).member_ids
+
+    async def create_membership(
+        self,
+        project_id: int,
+        principal_id: int,
+        role_ids: list[int],
+        *,
+        principal_type: str = 'user',
+    ) -> Membership:
+        """Add a principal (user or group) to a project with the given roles."""
+        base = 'groups' if principal_type == 'group' else 'users'
+        body = {
+            '_links': {
+                'project': {'href': f'/api/v3/projects/{project_id}'},
+                'principal': {'href': f'/api/v3/{base}/{principal_id}'},
+                'roles': [{'href': f'/api/v3/roles/{rid}'} for rid in role_ids],
+            }
+        }
+        data = await self._request('POST', '/memberships', json=body)
+        return Membership.from_api(data)
+
+    async def update_membership_roles(
+        self, membership_id: int, role_ids: list[int]
+    ) -> Membership:
+        """Set the roles of an existing membership (used to add missing roles)."""
+        body = {'_links': {'roles': [{'href': f'/api/v3/roles/{rid}'} for rid in role_ids]}}
+        data = await self._request('PATCH', f'/memberships/{membership_id}', json=body)
+        return Membership.from_api(data)
 
     async def get_custom_fields(
         self, *, project_ids: list[int], type_ids: list[int]

--- a/src/op/cli.py
+++ b/src/op/cli.py
@@ -39,10 +39,22 @@ def main() -> None:
 
 
 def _parse_args(argv: list[str], *, defaults: DefaultsConfig | None = None) -> argparse.Namespace:
+    # `op perms [projekt]` is a distinct mode (own TUI), kept separate from the
+    # work-package query parser so the positional `query` semantics are unchanged.
+    if argv and argv[0] == 'perms':
+        perms = argparse.ArgumentParser(prog='op perms')
+        perms.add_argument('project', nargs='?', help='Projekt-ID, -Name oder -Identifier')
+        ns = perms.parse_args(argv[1:])
+        return argparse.Namespace(
+            command='perms', perms_project=ns.project,
+            load_remote_data=False, interactive=False, query=[],
+        )
+
     parser = argparse.ArgumentParser(
         prog='op',
         description='Fast, keyboard-driven CLI and TUI for OpenProject.',
     )
+    parser.set_defaults(command=None)
     parser.add_argument(
         '--load-remote-data',
         action='store_true',
@@ -109,6 +121,9 @@ async def run(
             console.print('[green]Remote data loaded.[/green]')
             return 0
 
+        if getattr(args, 'command', None) == 'perms':
+            return await _run_perms(args, client, config, console)
+
         try:
             query = parse(args.query, defaults=config.defaults)
         except ValueError as exc:
@@ -162,6 +177,42 @@ async def run(
         for wp in results:
             console.print(format_result_line(wp, config.connection.base_url))
         return 0
+
+
+async def _run_perms(
+    args: argparse.Namespace,
+    client: OpenProjectClient,
+    config: Config,
+    console: Console,
+) -> int:
+    """Launch the interactive permission tool (`op perms [projekt]`)."""
+    if not config.remote.projects:
+        console.print(
+            '[red]Keine Projekt-Metadaten.[/red] Bitte zuerst `op --load-remote-data` ausführen.'
+        )
+        return 2
+    start = _resolve_project(args.perms_project, config) if args.perms_project else None
+    if args.perms_project and start is None:
+        console.print(f'[red]Projekt nicht gefunden:[/red] {args.perms_project!r}')
+        return 2
+    from op.tui.perms_app import PermsApp
+
+    app = PermsApp(config=config, client=client, start_project=start)
+    await app.run_async()
+    return 0
+
+
+def _resolve_project(token: str, config: Config) -> int | None:
+    """Resolve a project token (numeric id, exact name or case-insensitive substring)."""
+    projects = config.remote.projects
+    if token.isdigit() and int(token) in projects:
+        return int(token)
+    needle = token.casefold()
+    exact = [pid for pid, name in projects.items() if name.casefold() == needle]
+    if exact:
+        return exact[0]
+    subs = [pid for pid, name in projects.items() if needle in name.casefold()]
+    return subs[0] if len(subs) == 1 else (subs[0] if subs else None)
 
 
 async def _initial_tasks(

--- a/src/op/models.py
+++ b/src/op/models.py
@@ -85,10 +85,60 @@ class User(_ApiModel):
 class Group(_ApiModel):
     id: int
     name: str
+    member_ids: list[int] = Field(default_factory=list)
 
     @classmethod
     def from_api(cls, payload: dict[str, T.Any]) -> Group:
+        links = payload.get('_links') or {}
+        members = links.get('members') or []
+        member_ids = [
+            id_from_href(m.get('href'))
+            for m in members
+            if isinstance(m, dict)
+        ]
+        return cls(
+            id=payload['id'],
+            name=payload['name'],
+            member_ids=[m for m in member_ids if m is not None],
+        )
+
+
+class Role(_ApiModel):
+    id: int
+    name: str
+
+    @classmethod
+    def from_api(cls, payload: dict[str, T.Any]) -> Role:
         return cls(id=payload['id'], name=payload['name'])
+
+
+class Membership(_ApiModel):
+    """A project membership: which principal (user or group) holds which roles."""
+
+    id: int
+    project_id: int | None = None
+    principal_id: int | None = None
+    principal_name: str | None = None
+    principal_type: str = 'user'  # 'user' | 'group'
+    role_ids: list[int] = Field(default_factory=list)
+    role_names: list[str] = Field(default_factory=list)
+
+    @classmethod
+    def from_api(cls, payload: dict[str, T.Any]) -> Membership:
+        links = payload.get('_links') or {}
+        principal = links.get('principal') or {}
+        href = principal.get('href') or ''
+        principal_type = 'group' if '/groups/' in href else 'user'
+        roles = [r for r in links.get('roles', []) if isinstance(r, dict)]
+        return cls(
+            id=payload['id'],
+            project_id=_link_id(links, 'project'),
+            principal_id=id_from_href(href),
+            principal_name=principal.get('title'),
+            principal_type=principal_type,
+            role_ids=[rid for rid in (id_from_href(r.get('href')) for r in roles) if rid is not None],
+            role_names=[r.get('title') for r in roles if r.get('title')],
+        )
 
 
 class Activity(_ApiModel):

--- a/src/op/perms.py
+++ b/src/op/perms.py
@@ -1,0 +1,193 @@
+"""Pure permission logic for the `op perms` tool.
+
+OpenProject's v3 API exposes no `inherited_from` marker on memberships, so we
+reconstruct the *source* of a project's permissions from sets:
+
+- group memberships  (principal is a group)
+- direct users       (user memberships not covered by any member group)
+
+The per-user entries OpenProject materialises from a group membership are NOT
+treated as their own source — they are folded under their group. Transfer and
+hierarchy-propagation therefore always operate on the source set (groups +
+direct users); the target project re-materialises its own per-user entries.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from op.models import Membership
+
+
+def build_hierarchy(
+    projects: dict[int, str], parents: dict[int, int]
+) -> list[tuple[int, int, str]]:
+    """Return [(project_id, depth, name)] in parent-before-child order."""
+    children: dict[int | None, list[int]] = {}
+    for pid in projects:
+        parent = parents.get(pid)
+        children.setdefault(parent, []).append(pid)
+    for group in children.values():
+        group.sort(key=lambda pid: projects[pid].lower())
+
+    result: list[tuple[int, int, str]] = []
+
+    def _walk(parent: int | None, depth: int) -> None:
+        for pid in children.get(parent, []):
+            result.append((pid, depth, projects[pid]))
+            _walk(pid, depth + 1)
+
+    all_parent_keys = set(children.keys())
+    roots: set[int | None] = {None}
+    for parent in all_parent_keys:
+        if parent is None or parent not in projects:
+            roots.add(parent)
+    for root in sorted(roots, key=lambda k: (k is None, k or 0)):
+        _walk(root, 0)
+    return result
+
+
+def children_map(parents: dict[int, int]) -> dict[int, list[int]]:
+    """parent_id -> [direct child ids]."""
+    out: dict[int, list[int]] = {}
+    for child, parent in parents.items():
+        out.setdefault(parent, []).append(child)
+    return out
+
+
+def descendants(root_id: int, parents: dict[int, int]) -> list[int]:
+    """All descendant project ids of root_id (recursive, excludes root itself)."""
+    kids = children_map(parents)
+    result: list[int] = []
+    stack = list(kids.get(root_id, []))
+    while stack:
+        pid = stack.pop()
+        result.append(pid)
+        stack.extend(kids.get(pid, []))
+    return result
+
+
+@dataclass(frozen=True)
+class SourceEntry:
+    """One source-of-permission entry: a group or a direct user with its roles."""
+
+    kind: str           # 'group' | 'user'
+    principal_id: int
+    role_ids: frozenset[int]
+
+
+def build_source_set(
+    memberships: list[Membership], group_members: dict[int, list[int]]
+) -> set[SourceEntry]:
+    """Reconstruct the source set of a project from its memberships.
+
+    `group_members` maps group_id -> member user ids for the groups that are
+    members of this project. Users covered by such a group are folded away.
+    """
+    groups = [m for m in memberships if m.principal_type == 'group']
+    covered: set[int] = set()
+    for g in groups:
+        if g.principal_id is not None:
+            covered.update(group_members.get(g.principal_id, []))
+
+    out: set[SourceEntry] = set()
+    for g in groups:
+        if g.principal_id is not None:
+            out.add(SourceEntry('group', g.principal_id, frozenset(g.role_ids)))
+    for m in memberships:
+        if m.principal_type == 'user' and m.principal_id is not None:
+            if m.principal_id in covered:
+                continue  # visible via a group → not a direct source
+            out.add(SourceEntry('user', m.principal_id, frozenset(m.role_ids)))
+    return out
+
+
+def visible_members(
+    memberships: list[Membership], group_members: dict[int, list[int]]
+) -> dict[int, list[int]]:
+    """group_id -> user ids that gain access through that (project-member) group."""
+    out: dict[int, list[int]] = {}
+    for m in memberships:
+        if m.principal_type == 'group' and m.principal_id is not None:
+            out[m.principal_id] = list(group_members.get(m.principal_id, []))
+    return out
+
+
+def missing_entries(
+    parent_set: set[SourceEntry], child_set: set[SourceEntry]
+) -> set[SourceEntry]:
+    """Source entries present in the parent but missing (by principal) in the child.
+
+    Compares per principal: an entry is missing if the child has no entry for
+    that (kind, principal_id), OR the child's roles for it don't cover the
+    parent's roles (additive — missing roles count too).
+    """
+    child_by_principal: dict[tuple[str, int], frozenset[int]] = {}
+    for e in child_set:
+        key = (e.kind, e.principal_id)
+        child_by_principal[key] = child_by_principal.get(key, frozenset()) | e.role_ids
+
+    out: set[SourceEntry] = set()
+    for e in parent_set:
+        have = child_by_principal.get((e.kind, e.principal_id))
+        if have is None:
+            out.add(e)
+        elif not e.role_ids <= have:
+            out.add(SourceEntry(e.kind, e.principal_id, e.role_ids - have))
+    return out
+
+
+def has_mismatch(parent_set: set[SourceEntry], child_set: set[SourceEntry]) -> bool:
+    return bool(missing_entries(parent_set, child_set))
+
+
+@dataclass
+class PendingMembership:
+    """A planned additive membership change for one project + principal."""
+
+    project_id: int
+    kind: str            # 'group' | 'user'
+    principal_id: int
+    role_ids: set[int] = field(default_factory=set)
+
+
+def _pending_from_missing(project_id: int, missing: set[SourceEntry]) -> list[PendingMembership]:
+    return [
+        PendingMembership(project_id, e.kind, e.principal_id, set(e.role_ids))
+        for e in missing
+    ]
+
+
+def plan_transfer(
+    src_set: set[SourceEntry], dst_set: set[SourceEntry], dst_project_id: int
+) -> list[PendingMembership]:
+    """Additive transfer of src's source entries into dst."""
+    return _pending_from_missing(dst_project_id, missing_entries(src_set, dst_set))
+
+
+def plan_propagation(
+    root_id: int,
+    parents: dict[int, int],
+    source_sets: dict[int, set[SourceEntry]],
+) -> list[PendingMembership]:
+    """Recursively align every descendant of root_id with its own parent.
+
+    For each descendant we add the source entries its direct parent has but it
+    lacks. Walking top-down means a fix on an upper level is seen by the levels
+    below within the same pass.
+    """
+    plans: list[PendingMembership] = []
+    # Effective (post-fix) source set per project as we walk down.
+    effective: dict[int, set[SourceEntry]] = {
+        root_id: set(source_sets.get(root_id, set()))
+    }
+    for child in descendants(root_id, parents):
+        parent = parents.get(child)
+        parent_set = effective.get(parent, source_sets.get(parent, set()))
+        child_set = set(source_sets.get(child, set()))
+        missing = missing_entries(parent_set, child_set)
+        if missing:
+            plans.extend(_pending_from_missing(child, missing))
+        # child now effectively has parent's entries too (for deeper levels)
+        effective[child] = child_set | parent_set
+    return plans

--- a/src/op/perms_queue.py
+++ b/src/op/perms_queue.py
@@ -1,0 +1,69 @@
+"""Pending-membership queue for the `op perms` review-before-apply workflow.
+
+Collects additive membership changes (one per project + principal). Re-queuing
+the same (project, principal) merges the role sets (union). Mirrors the
+shape/status model of `queue.OperationQueue`.
+"""
+
+from __future__ import annotations
+
+import typing as T
+from dataclasses import dataclass, field
+
+from op.perms import PendingMembership
+
+OperationStatus = T.Literal['pending', 'running', 'done', 'failed']
+
+
+@dataclass
+class PendingMembershipOp:
+    project_id: int
+    kind: str            # 'group' | 'user'
+    principal_id: int
+    role_ids: set[int] = field(default_factory=set)
+    status: OperationStatus = 'pending'
+    error: str | None = None
+
+    @property
+    def key(self) -> tuple[int, str, int]:
+        return (self.project_id, self.kind, self.principal_id)
+
+
+class PermissionQueue:
+    """Ordered map of (project, kind, principal) → pending membership op."""
+
+    def __init__(self) -> None:
+        self._ops: dict[tuple[int, str, int], PendingMembershipOp] = {}
+
+    @property
+    def count(self) -> int:
+        return len(self._ops)
+
+    def add(self, pending: PendingMembership) -> None:
+        key = (pending.project_id, pending.kind, pending.principal_id)
+        existing = self._ops.get(key)
+        if existing is None:
+            self._ops[key] = PendingMembershipOp(
+                project_id=pending.project_id,
+                kind=pending.kind,
+                principal_id=pending.principal_id,
+                role_ids=set(pending.role_ids),
+            )
+        else:
+            existing.role_ids |= set(pending.role_ids)
+
+    def add_many(self, pendings: list[PendingMembership]) -> None:
+        for p in pendings:
+            self.add(p)
+
+    def remove(self, key: tuple[int, str, int]) -> None:
+        self._ops.pop(key, None)
+
+    def all(self) -> list[PendingMembershipOp]:
+        return list(self._ops.values())
+
+    def clear(self) -> None:
+        self._ops.clear()
+
+    def clear_done(self) -> None:
+        self._ops = {k: op for k, op in self._ops.items() if op.status != 'done'}

--- a/src/op/tui/perms_app.py
+++ b/src/op/tui/perms_app.py
@@ -1,0 +1,110 @@
+"""Root Textual app for the `op perms` permission tool.
+
+Separate from OpApp (no task/work-package state). Loads project memberships
+live (not from the --load-remote-data cache, which only holds stable metadata),
+reconstructs each project's *source set* (groups + direct users), and hosts the
+project tree / detail / review / applying screens.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import typing as T
+
+from textual.app import App
+
+from op.config import Config
+from op.models import Membership
+from op.perms import SourceEntry, build_source_set
+from op.perms_queue import PermissionQueue
+
+
+class PermsApp(App[None]):
+    TITLE = 'op perms'
+
+    CSS = """
+    Screen { layers: base overlay; }
+    #perms-projects, #perms-detail, #perms-review, #perms-applying {
+        height: 1fr;
+        scrollbar-size-horizontal: 0;
+        overflow-x: hidden;
+    }
+    #perms-applying-progress { dock: bottom; width: 100%; height: 1; }
+    #perms-applying-errors {
+        height: auto; max-height: 10; border-top: solid $error;
+        background: $panel; padding: 0 1; display: none;
+    }
+    #perms-applying-errors.visible { display: block; }
+    """
+
+    def __init__(
+        self,
+        *,
+        config: Config,
+        client: T.Any,
+        start_project: int | None = None,
+    ) -> None:
+        super().__init__()
+        self.config = config
+        self.client = client
+        self.start_project = start_project
+        self.perms_queue = PermissionQueue()
+
+        self.projects: dict[int, str] = dict(config.remote.projects)
+        self.parents: dict[int, int] = dict(config.remote.project_parents)
+        self.roles: dict[int, str] = {}
+        self.memberships: dict[int, list[Membership]] = {}
+        self.group_members: dict[int, list[int]] = {}
+        self.source_sets: dict[int, set[SourceEntry]] = {}
+        self.loaded = False
+
+    def on_mount(self) -> None:
+        from op.tui.perms_projects_screen import PermsProjectsScreen
+
+        self.push_screen(PermsProjectsScreen())
+
+    async def load_data(self) -> None:
+        """Fetch roles, all project memberships and the referenced group member lists,
+        then compute the source set per project. Idempotent."""
+        if self.loaded:
+            return
+        roles = await self.client.get_roles()
+        self.roles = {r.id: r.name for r in roles}
+
+        project_ids = list(self.projects)
+        results = await asyncio.gather(
+            *(self.client.get_memberships(pid) for pid in project_ids),
+            return_exceptions=True,
+        )
+        for pid, res in zip(project_ids, results):
+            self.memberships[pid] = [] if isinstance(res, Exception) else res
+
+        group_ids = {
+            m.principal_id
+            for ms in self.memberships.values()
+            for m in ms
+            if m.principal_type == 'group' and m.principal_id is not None
+        }
+        gm = await asyncio.gather(
+            *(self.client.get_group_members(gid) for gid in group_ids),
+            return_exceptions=True,
+        )
+        for gid, res in zip(group_ids, gm):
+            self.group_members[gid] = [] if isinstance(res, Exception) else res
+
+        self.source_sets = {
+            pid: build_source_set(ms, self.group_members)
+            for pid, ms in self.memberships.items()
+        }
+        self.loaded = True
+
+    def source_set(self, project_id: int) -> set[SourceEntry]:
+        return self.source_sets.get(project_id, set())
+
+    def role_label(self, role_ids: T.Iterable[int]) -> str:
+        return ', '.join(self.roles.get(r, f'#{r}') for r in role_ids)
+
+    def principal_label(self, kind: str, principal_id: int) -> str:
+        if kind == 'group':
+            return self.config.remote.groups.get(principal_id, f'Gruppe #{principal_id}')
+        return self.config.remote.users.get(principal_id, f'User #{principal_id}')

--- a/src/op/tui/perms_applying_screen.py
+++ b/src/op/tui/perms_applying_screen.py
@@ -1,0 +1,136 @@
+"""Applying screen for `op perms` — executes queued membership changes (additive).
+
+For each (project, principal): if the principal is already a member, add the
+missing roles via PATCH; otherwise create the membership. Mirrors the
+status/progress model of tui/applying_screen.py.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from rich.text import Text
+from textual.binding import Binding
+from textual.screen import Screen
+from textual.widgets import DataTable, Footer, Header, ProgressBar, RichLog
+
+log = logging.getLogger(__name__)
+
+_COL_STATUS = 'status'
+_COL_TEXT = 'text'
+
+_STATUS_MARK = {
+    'pending': Text('·', style='dim'),
+    'running': Text('⟳', style='bold yellow'),
+    'done':    Text('✓', style='bold green'),
+    'failed':  Text('✗', style='bold red'),
+}
+
+
+class PermsApplyingScreen(Screen[None]):
+    BINDINGS = [Binding('q', 'close', 'Close', show=True)]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.is_done = False
+        self._has_failures = False
+
+    def compose(self):  # noqa: ANN201
+        yield Header()
+        yield DataTable(id='perms-applying', cursor_type='row', zebra_stripes=True)
+        yield RichLog(id='perms-applying-errors', wrap=True, highlight=False, markup=True)
+        yield ProgressBar(id='perms-applying-progress', show_eta=False)
+        yield Footer()
+
+    def on_mount(self) -> None:
+        self.app.sub_title = 'Anwenden…'
+        table = self.query_one('#perms-applying', DataTable)
+        table.add_column('', key=_COL_STATUS, width=3)
+        table.add_column('Änderung', key=_COL_TEXT)
+        ops = self.app.perms_queue.all()
+        if not ops:
+            self._return_to_root()
+            return
+        for op in ops:
+            table.add_row(_STATUS_MARK['pending'], self._describe(op), key=self._key(op))
+        self.query_one('#perms-applying-progress', ProgressBar).update(
+            total=len(ops), progress=0
+        )
+        self.run_worker(self._run(), exclusive=True)
+
+    def _key(self, op) -> str:  # noqa: ANN001
+        return f'{op.project_id}:{op.kind}:{op.principal_id}'
+
+    def _describe(self, op) -> str:  # noqa: ANN001
+        proj = self.app.projects.get(op.project_id, str(op.project_id))
+        who = self.app.principal_label(op.kind, op.principal_id)
+        return f'{proj}: + {who} [{self.app.role_label(sorted(op.role_ids))}]'
+
+    async def _run(self) -> None:
+        ops = self.app.perms_queue.all()
+        table = self.query_one('#perms-applying', DataTable)
+        progress = self.query_one('#perms-applying-progress', ProgressBar)
+        for index, op in enumerate(ops):
+            op.status = 'running'
+            table.update_cell(self._key(op), _COL_STATUS, _STATUS_MARK['running'])
+            ok = await self._apply_single(op)
+            mark = 'done' if ok else 'failed'
+            op.status = mark
+            if not ok:
+                self._has_failures = True
+                self._log_error(op)
+            table.update_cell(self._key(op), _COL_STATUS, _STATUS_MARK[mark])
+            progress.update(progress=index + 1)
+        self.is_done = True
+        self.app.perms_queue.clear_done()
+        self.app.loaded = False  # force reload so the tree reflects the new state
+        if not self._has_failures:
+            self._return_to_root()
+
+    async def _apply_single(self, op) -> bool:  # noqa: ANN001
+        existing = self._existing_membership(op)
+        try:
+            if existing is None:
+                await self.app.client.create_membership(
+                    op.project_id, op.principal_id, sorted(op.role_ids),
+                    principal_type=op.kind,
+                )
+            else:
+                union = set(existing.role_ids) | op.role_ids
+                if union != set(existing.role_ids):
+                    await self.app.client.update_membership_roles(
+                        existing.id, sorted(union)
+                    )
+        except Exception as exc:  # noqa: BLE001
+            op.error = str(exc) or exc.__class__.__name__
+            log.exception('perms apply failed for %s: %s', self._key(op), exc)
+            return False
+        return True
+
+    def _existing_membership(self, op):  # noqa: ANN001, ANN202
+        for m in self.app.memberships.get(op.project_id, []):
+            if m.principal_type == op.kind and m.principal_id == op.principal_id:
+                return m
+        return None
+
+    def _log_error(self, op) -> None:  # noqa: ANN001
+        widget = self.query_one('#perms-applying-errors', RichLog)
+        if 'visible' not in widget.classes:
+            widget.add_class('visible')
+        widget.write(f'[red]{self._describe(op)} — {op.error}[/red]')
+
+    def action_close(self) -> None:
+        if not self.is_done:
+            return
+        if self._has_failures:
+            self.app.pop_screen()
+        else:
+            self._return_to_root()
+
+    def _return_to_root(self) -> None:
+        from op.tui.perms_projects_screen import PermsProjectsScreen
+
+        while not isinstance(self.app.screen, PermsProjectsScreen):
+            if len(self.app.screen_stack) <= 1:
+                break
+            self.app.pop_screen()

--- a/src/op/tui/perms_detail_screen.py
+++ b/src/op/tui/perms_detail_screen.py
@@ -1,0 +1,81 @@
+"""Detail view for `op perms` — principals of one project, group-centric.
+
+Groups are shown as the unit with their visible members nested beneath them;
+genuinely-direct users are listed separately. The materialised per-user entries
+OpenProject creates from a group are NOT listed individually (folded away).
+"""
+
+from __future__ import annotations
+
+from rich.text import Text
+from textual.binding import Binding
+from textual.screen import Screen
+from textual.widgets import DataTable, Footer, Header
+
+from op.perms import build_source_set, visible_members
+
+
+class PermsDetailScreen(Screen[None]):
+    BINDINGS = [
+        Binding('q', 'back', 'Zurück', show=True),
+        Binding('escape', 'back', 'Zurück', show=False),
+    ]
+
+    def __init__(self, project_id: int) -> None:
+        super().__init__()
+        self.project_id = project_id
+
+    def compose(self):  # noqa: ANN201
+        yield Header()
+        yield DataTable(id='perms-detail', cursor_type='row', zebra_stripes=True)
+        yield Footer()
+
+    def on_mount(self) -> None:
+        name = self.app.projects.get(self.project_id, str(self.project_id))
+        self.app.sub_title = f'Berechtigungen · {name}'
+        table = self.query_one('#perms-detail', DataTable)
+        table.add_column('Principal')
+        table.add_column('Rollen', width=30)
+
+        memberships = self.app.memberships.get(self.project_id, [])
+        source = build_source_set(memberships, self.app.group_members)
+        vis = visible_members(memberships, self.app.group_members)
+        roles_by_principal = {
+            (e.kind, e.principal_id): sorted(e.role_ids) for e in source
+        }
+
+        groups = sorted(
+            (e for e in source if e.kind == 'group'),
+            key=lambda e: self.app.principal_label('group', e.principal_id).lower(),
+        )
+        users = sorted(
+            (e for e in source if e.kind == 'user'),
+            key=lambda e: self.app.principal_label('user', e.principal_id).lower(),
+        )
+
+        if not groups and not users:
+            table.add_row(Text('(keine direkten Berechtigungen)', style='dim'), '')
+            return
+
+        for g in groups:
+            gname = self.app.principal_label('group', g.principal_id)
+            table.add_row(
+                Text(f'▸ {gname}', style='bold'),
+                self.app.role_label(roles_by_principal[('group', g.principal_id)]),
+            )
+            for uid in sorted(
+                vis.get(g.principal_id, []),
+                key=lambda u: self.app.principal_label('user', u).lower(),
+            ):
+                table.add_row(
+                    Text(f'    {self.app.principal_label("user", uid)}', style='dim'),
+                    Text('via Gruppe', style='dim'),
+                )
+        for u in users:
+            table.add_row(
+                self.app.principal_label('user', u.principal_id),
+                self.app.role_label(roles_by_principal[('user', u.principal_id)]),
+            )
+
+    def action_back(self) -> None:
+        self.app.pop_screen()

--- a/src/op/tui/perms_projects_screen.py
+++ b/src/op/tui/perms_projects_screen.py
@@ -1,0 +1,216 @@
+"""Project tree for `op perms` — shows hierarchy with permission-mismatch flags."""
+
+from __future__ import annotations
+
+from rich.text import Text
+from textual.binding import Binding
+from textual.screen import ModalScreen, Screen
+from textual.widgets import DataTable, Footer, Header, Label
+
+from op.perms import build_hierarchy, has_mismatch, plan_propagation, plan_transfer
+
+_COL_FLAG = 'flag'
+_COL_ID = 'id'
+_COL_NAME = 'name'
+
+_FLAG_MISMATCH = Text('▲', style='bold yellow')
+_FLAG_OK = Text(' ')
+
+
+class PermsProjectsScreen(Screen[None]):
+    """Hierarchical project list. `▲` marks a project whose source set differs
+    from its parent's (additive view)."""
+
+    BINDINGS = [
+        Binding('c', 'copy', 'Von Projekt übertragen', show=True),
+        Binding('f', 'fix', 'Hierarchie angleichen', show=True),
+        Binding('g', 'review', 'Review/Apply', show=True),
+        Binding('r', 'reload', 'Neu laden', show=True),
+        Binding('q', 'quit_app', 'Quit', show=True),
+    ]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._rows: list[tuple[int, int, str]] = []
+
+    def compose(self):  # noqa: ANN201
+        yield Header()
+        yield Label('Lade Berechtigungen…', id='perms-loading')
+        yield DataTable(id='perms-projects', cursor_type='row', zebra_stripes=True)
+        yield Footer()
+
+    def on_mount(self) -> None:
+        table = self.query_one('#perms-projects', DataTable)
+        table.add_column('', key=_COL_FLAG, width=3)
+        table.add_column('ID', key=_COL_ID, width=8)
+        table.add_column('Projekt', key=_COL_NAME)
+        self.run_worker(self._load_and_populate(), exclusive=True)
+
+    async def _load_and_populate(self) -> None:
+        await self.app.load_data()
+        self.query_one('#perms-loading', Label).display = False
+        self._populate()
+        self._update_subtitle()
+
+    def _populate(self) -> None:
+        table = self.query_one('#perms-projects', DataTable)
+        table.clear()
+        self._rows = build_hierarchy(self.app.projects, self.app.parents)
+        for pid, depth, name in self._rows:
+            table.add_row(
+                self._flag_for(pid),
+                str(pid),
+                '  ' * depth + name,
+                key=str(pid),
+            )
+        if self.app.start_project is not None:
+            self._move_cursor_to(self.app.start_project)
+
+    def _flag_for(self, pid: int) -> Text:
+        parent = self.app.parents.get(pid)
+        if parent is None or parent not in self.app.projects:
+            return _FLAG_OK
+        if has_mismatch(self.app.source_set(parent), self.app.source_set(pid)):
+            return _FLAG_MISMATCH
+        return _FLAG_OK
+
+    def _move_cursor_to(self, pid: int) -> None:
+        for i, (rid, _, _) in enumerate(self._rows):
+            if rid == pid:
+                self.query_one('#perms-projects', DataTable).move_cursor(row=i)
+                return
+
+    def _current_project(self) -> int | None:
+        table = self.query_one('#perms-projects', DataTable)
+        if table.cursor_row is None or not self._rows:
+            return None
+        return self._rows[table.cursor_row][0]
+
+    def _update_subtitle(self) -> None:
+        n = self.app.perms_queue.count
+        self.app.sub_title = f'{n} geplante Änderung(en)' if n else 'Berechtigungen'
+
+    # --- actions ---------------------------------------------------------
+
+    def on_data_table_row_selected(self, event: DataTable.RowSelected) -> None:
+        from op.tui.perms_detail_screen import PermsDetailScreen
+
+        self.app.push_screen(PermsDetailScreen(int(event.row_key.value)))
+
+    def action_fix(self) -> None:
+        pid = self._current_project()
+        if pid is None:
+            return
+        plans = plan_propagation(pid, self.app.parents, self.app.source_sets)
+        if not plans:
+            self.notify('Teilbaum ist bereits konsistent.', timeout=4)
+            return
+        self.app.perms_queue.add_many(plans)
+        self._update_subtitle()
+        self.notify(
+            f'{len(plans)} Angleichung(en) eingeplant für den Teilbaum von '
+            f'{self.app.projects.get(pid, pid)}. "g" zum Review.',
+            timeout=6,
+        )
+
+    def action_copy(self) -> None:
+        dst = self._current_project()
+        if dst is None:
+            return
+
+        def _on_pick(src: int | None) -> None:
+            if src is None or src == dst:
+                return
+            plans = plan_transfer(
+                self.app.source_set(src), self.app.source_set(dst), dst
+            )
+            if not plans:
+                self.notify('Ziel hat bereits alle Quell-Berechtigungen.', timeout=4)
+                return
+            self.app.perms_queue.add_many(plans)
+            self._update_subtitle()
+            self.notify(
+                f'{len(plans)} Übertragung(en) von {self.app.projects.get(src, src)} '
+                f'→ {self.app.projects.get(dst, dst)} eingeplant. "g" zum Review.',
+                timeout=6,
+            )
+
+        self.app.push_screen(
+            PermsProjectPickerScreen(self._rows, title='Quell-Projekt wählen'), _on_pick
+        )
+
+    def action_review(self) -> None:
+        if self.app.perms_queue.count == 0:
+            self.notify('Keine geplanten Änderungen.', timeout=3)
+            return
+        from op.tui.perms_review_screen import PermsReviewScreen
+
+        self.app.push_screen(PermsReviewScreen())
+
+    def action_reload(self) -> None:
+        self.app.loaded = False
+        self.app.memberships.clear()
+        self.app.group_members.clear()
+        self.app.source_sets.clear()
+        self.query_one('#perms-loading', Label).display = True
+        self.run_worker(self._load_and_populate(), exclusive=True)
+
+    def action_quit_app(self) -> None:
+        self.app.exit()
+
+    def on_screen_resume(self) -> None:
+        if self.app.loaded:
+            self._populate()
+            self._update_subtitle()
+
+
+class PermsProjectPickerScreen(ModalScreen[int | None]):
+    """Modal hierarchical project picker; returns the chosen project id."""
+
+    BINDINGS = [
+        Binding('enter', 'pick', 'Wählen', show=True),
+        Binding('escape', 'cancel', 'Abbrechen', show=True),
+    ]
+
+    DEFAULT_CSS = """
+    PermsProjectPickerScreen { align: center middle; }
+    PermsProjectPickerScreen > Vertical {
+        background: $panel; border: round $accent; padding: 0 1;
+        width: 70; height: auto; max-height: 80%;
+    }
+    PermsProjectPickerScreen DataTable { height: auto; max-height: 24; }
+    """
+
+    def __init__(self, rows: list[tuple[int, int, str]], *, title: str) -> None:
+        super().__init__()
+        self._rows = rows
+        self._title = title
+
+    def compose(self):  # noqa: ANN201
+        from textual.containers import Vertical
+
+        with Vertical():
+            yield Label(self._title)
+            yield DataTable(id='perms-picker', cursor_type='row', zebra_stripes=True)
+            yield Footer()
+
+    def on_mount(self) -> None:
+        table = self.query_one('#perms-picker', DataTable)
+        table.add_column('ID', width=8)
+        table.add_column('Projekt')
+        for pid, depth, name in self._rows:
+            table.add_row(str(pid), '  ' * depth + name, key=str(pid))
+        table.focus()
+
+    def action_pick(self) -> None:
+        table = self.query_one('#perms-picker', DataTable)
+        if table.cursor_row is None or not self._rows:
+            self.dismiss(None)
+            return
+        self.dismiss(self._rows[table.cursor_row][0])
+
+    def on_data_table_row_selected(self, event: DataTable.RowSelected) -> None:
+        self.dismiss(int(event.row_key.value))
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)

--- a/src/op/tui/perms_review_screen.py
+++ b/src/op/tui/perms_review_screen.py
@@ -1,0 +1,69 @@
+"""Review screen for `op perms` — list planned membership additions before apply."""
+
+from __future__ import annotations
+
+from rich.text import Text
+from textual.binding import Binding
+from textual.screen import Screen
+from textual.widgets import DataTable, Footer, Header
+
+
+class PermsReviewScreen(Screen[None]):
+    BINDINGS = [
+        Binding('d', 'delete', 'Entfernen', show=True),
+        Binding('g', 'apply', 'Anwenden', show=True),
+        Binding('q', 'back', 'Zurück', show=True),
+        Binding('escape', 'back', 'Zurück', show=False),
+    ]
+
+    def compose(self):  # noqa: ANN201
+        yield Header()
+        yield DataTable(id='perms-review', cursor_type='row', zebra_stripes=True)
+        yield Footer()
+
+    def on_mount(self) -> None:
+        self.app.sub_title = 'Review geplanter Berechtigungen'
+        table = self.query_one('#perms-review', DataTable)
+        table.add_column('Projekt')
+        table.add_column('Principal')
+        table.add_column('Rollen', width=24)
+        self._populate()
+
+    def _populate(self) -> None:
+        table = self.query_one('#perms-review', DataTable)
+        table.clear()
+        for op in self.app.perms_queue.all():
+            table.add_row(
+                self.app.projects.get(op.project_id, str(op.project_id)),
+                self._principal_label(op),
+                self.app.role_label(sorted(op.role_ids)),
+                key=f'{op.project_id}:{op.kind}:{op.principal_id}',
+            )
+        if self.app.perms_queue.count == 0:
+            self.app.pop_screen()
+
+    def _principal_label(self, op) -> Text:  # noqa: ANN001
+        label = self.app.principal_label(op.kind, op.principal_id)
+        prefix = '▸ ' if op.kind == 'group' else ''
+        return Text(f'{prefix}{label}', style='bold' if op.kind == 'group' else '')
+
+    def action_delete(self) -> None:
+        table = self.query_one('#perms-review', DataTable)
+        if table.cursor_row is None:
+            return
+        ops = self.app.perms_queue.all()
+        if table.cursor_row >= len(ops):
+            return
+        op = ops[table.cursor_row]
+        self.app.perms_queue.remove(op.key)
+        self._populate()
+
+    def action_apply(self) -> None:
+        if self.app.perms_queue.count == 0:
+            return
+        from op.tui.perms_applying_screen import PermsApplyingScreen
+
+        self.app.push_screen(PermsApplyingScreen())
+
+    def action_back(self) -> None:
+        self.app.pop_screen()

--- a/src/op/tui/project_filter_screen.py
+++ b/src/op/tui/project_filter_screen.py
@@ -19,42 +19,13 @@ from textual.screen import Screen
 from textual.widgets import DataTable, Footer, Header
 
 from op.config import Config, update_filter
+from op.perms import build_hierarchy as _build_hierarchy
 
 log = logging.getLogger(__name__)
 
 _COL_CHECK = 'check'
 _COL_ID = 'id'
 _COL_NAME = 'name'
-
-
-def _build_hierarchy(
-    projects: dict[int, str], parents: dict[int, int]
-) -> list[tuple[int, int, str]]:
-    """Return [(project_id, depth, name)] in parent-before-child order."""
-    children: dict[int | None, list[int]] = {}
-    for pid in projects:
-        parent = parents.get(pid)
-        children.setdefault(parent, []).append(pid)
-    # Stable order by project name
-    for group in children.values():
-        group.sort(key=lambda pid: projects[pid].lower())
-
-    result: list[tuple[int, int, str]] = []
-
-    def _walk(parent: int | None, depth: int) -> None:
-        for pid in children.get(parent, []):
-            result.append((pid, depth, projects[pid]))
-            _walk(pid, depth + 1)
-
-    # Roots: parents that don't exist in projects, plus explicit None
-    all_parent_keys = set(children.keys())
-    roots: set[int | None] = {None}
-    for parent in all_parent_keys:
-        if parent is None or parent not in projects:
-            roots.add(parent)
-    for root in sorted(roots, key=lambda k: (k is None, k or 0)):
-        _walk(root, 0)
-    return result
 
 
 class ProjectFilterScreen(Screen[None]):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -8,8 +8,10 @@ from op.models import (
     Activity,
     CustomField,
     Group,
+    Membership,
     Priority,
     Project,
+    Role,
     Status,
     User,
     WorkPackage,
@@ -65,6 +67,58 @@ class TestSimpleLookups:
     def test_group_from_api(self) -> None:
         payload = {'_type': 'Group', 'id': 12, 'name': 'DevOps-Team'}
         assert Group.from_api(payload) == Group(id=12, name='DevOps-Team')
+
+    def test_group_from_api_parses_members(self) -> None:
+        payload = {
+            '_type': 'Group', 'id': 6, 'name': 'KB',
+            '_links': {
+                'members': [
+                    {'href': '/api/v3/users/33', 'title': 'Grit Keiwel'},
+                    {'href': '/api/v3/users/34', 'title': 'Christian Düster'},
+                ],
+            },
+        }
+        g = Group.from_api(payload)
+        assert g.member_ids == [33, 34]
+
+    def test_role_from_api(self) -> None:
+        r = Role.from_api({'_type': 'Role', 'id': 3, 'name': 'Member'})
+        assert r == Role(id=3, name='Member')
+
+    def test_membership_from_api_user(self) -> None:
+        payload = {
+            '_type': 'Membership', 'id': 2879,
+            '_links': {
+                'project': {'href': '/api/v3/projects/106', 'title': 'StBVS'},
+                'principal': {'href': '/api/v3/users/33', 'title': 'Grit Keiwel gke'},
+                'roles': [{'href': '/api/v3/roles/3', 'title': 'Member'}],
+            },
+        }
+        m = Membership.from_api(payload)
+        assert m.id == 2879
+        assert m.project_id == 106
+        assert m.principal_id == 33
+        assert m.principal_type == 'user'
+        assert m.principal_name == 'Grit Keiwel gke'
+        assert m.role_ids == [3]
+        assert m.role_names == ['Member']
+
+    def test_membership_from_api_group(self) -> None:
+        payload = {
+            '_type': 'Membership', 'id': 2877,
+            '_links': {
+                'project': {'href': '/api/v3/projects/106'},
+                'principal': {'href': '/api/v3/groups/6', 'title': 'KB'},
+                'roles': [
+                    {'href': '/api/v3/roles/3', 'title': 'Member'},
+                    {'href': '/api/v3/roles/5', 'title': 'Project admin'},
+                ],
+            },
+        }
+        m = Membership.from_api(payload)
+        assert m.principal_type == 'group'
+        assert m.principal_id == 6
+        assert m.role_ids == [3, 5]
 
 
 class TestWorkPackage:

--- a/tests/test_perms.py
+++ b/tests/test_perms.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from op.models import Membership
+from op.perms import (
+    SourceEntry,
+    build_hierarchy,
+    build_source_set,
+    descendants,
+    has_mismatch,
+    missing_entries,
+    plan_propagation,
+    plan_transfer,
+    visible_members,
+)
+
+
+def _m(mid: int, kind: str, pid: int, roles: list[int]) -> Membership:
+    return Membership(
+        id=mid, project_id=106, principal_id=pid, principal_name=f'p{pid}',
+        principal_type=kind, role_ids=roles,
+    )
+
+
+class TestSourceSet:
+    def test_group_folds_its_members(self) -> None:
+        # KB group (id 6) is a member; its members 33/34 also have materialised entries.
+        memberships = [
+            _m(1, 'group', 6, [3]),
+            _m(2, 'user', 33, [3]),   # materialised from group
+            _m(3, 'user', 34, [3]),   # materialised from group
+            _m(4, 'user', 19, [5]),   # genuine direct member (Project admin)
+        ]
+        group_members = {6: [33, 34]}
+        src = build_source_set(memberships, group_members)
+        assert SourceEntry('group', 6, frozenset({3})) in src
+        assert SourceEntry('user', 19, frozenset({5})) in src
+        # folded-away users do NOT appear as direct sources
+        assert not any(e.kind == 'user' and e.principal_id in (33, 34) for e in src)
+
+    def test_user_both_in_group_and_direct_is_folded(self) -> None:
+        memberships = [_m(1, 'group', 6, [3]), _m(2, 'user', 33, [3])]
+        src = build_source_set(memberships, {6: [33]})
+        assert src == {SourceEntry('group', 6, frozenset({3}))}
+
+    def test_visible_members(self) -> None:
+        memberships = [_m(1, 'group', 6, [3]), _m(2, 'user', 19, [5])]
+        assert visible_members(memberships, {6: [33, 34]}) == {6: [33, 34]}
+
+
+class TestMissing:
+    def test_missing_principal(self) -> None:
+        parent = {SourceEntry('group', 6, frozenset({3})), SourceEntry('user', 19, frozenset({5}))}
+        child = {SourceEntry('user', 19, frozenset({5}))}
+        assert missing_entries(parent, child) == {SourceEntry('group', 6, frozenset({3}))}
+        assert has_mismatch(parent, child)
+
+    def test_missing_role_only(self) -> None:
+        parent = {SourceEntry('user', 19, frozenset({3, 5}))}
+        child = {SourceEntry('user', 19, frozenset({3}))}
+        assert missing_entries(parent, child) == {SourceEntry('user', 19, frozenset({5}))}
+
+    def test_no_mismatch_when_child_superset(self) -> None:
+        parent = {SourceEntry('group', 6, frozenset({3}))}
+        child = {SourceEntry('group', 6, frozenset({3})), SourceEntry('user', 7, frozenset({3}))}
+        assert not has_mismatch(parent, child)
+
+
+class TestPlanTransfer:
+    def test_transfer_adds_only_missing(self) -> None:
+        src = {SourceEntry('group', 6, frozenset({3})), SourceEntry('user', 19, frozenset({5}))}
+        dst = {SourceEntry('user', 19, frozenset({5}))}
+        plans = plan_transfer(src, dst, dst_project_id=200)
+        assert len(plans) == 1
+        p = plans[0]
+        assert (p.project_id, p.kind, p.principal_id, p.role_ids) == (200, 'group', 6, {3})
+
+
+class TestHierarchy:
+    def test_build_hierarchy_order(self) -> None:
+        projects = {1: 'A', 2: 'B', 3: 'C'}
+        parents = {2: 1, 3: 2}
+        assert build_hierarchy(projects, parents) == [(1, 0, 'A'), (2, 1, 'B'), (3, 2, 'C')]
+
+    def test_descendants_recursive(self) -> None:
+        parents = {2: 1, 3: 2, 4: 1}
+        assert sorted(descendants(1, parents)) == [2, 3, 4]
+
+    def test_plan_propagation_recursive(self) -> None:
+        # 1 (parent) has group KB(6); 2 (child of 1) and 3 (child of 2) lack it.
+        parents = {2: 1, 3: 2}
+        kb = SourceEntry('group', 6, frozenset({3}))
+        source_sets = {1: {kb}, 2: set(), 3: set()}
+        plans = plan_propagation(1, parents, source_sets)
+        targets = {(p.project_id, p.kind, p.principal_id) for p in plans}
+        assert targets == {(2, 'group', 6), (3, 'group', 6)}
+
+    def test_plan_propagation_skips_already_aligned(self) -> None:
+        parents = {2: 1}
+        kb = SourceEntry('group', 6, frozenset({3}))
+        source_sets = {1: {kb}, 2: {kb}}
+        assert plan_propagation(1, parents, source_sets) == []

--- a/tests/test_perms_api.py
+++ b/tests/test_perms_api.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import json
+import typing as T
+
+import httpx
+import pytest
+import respx
+
+from op.api import OpenProjectClient
+
+BASE_URL = 'https://op.example.com'
+API_KEY = 'testkey'
+
+
+@pytest.fixture
+def client() -> OpenProjectClient:
+    return OpenProjectClient(base_url=BASE_URL, api_key=API_KEY)
+
+
+def _collection(elements: list[dict[str, T.Any]], total: int | None = None) -> dict[str, T.Any]:
+    return {
+        'total': total if total is not None else len(elements),
+        'count': len(elements),
+        '_embedded': {'elements': elements},
+    }
+
+
+def _membership(mid: int, principal_href: str, name: str, role_ids: list[int]) -> dict[str, T.Any]:
+    return {
+        '_type': 'Membership', 'id': mid,
+        '_links': {
+            'project': {'href': '/api/v3/projects/106', 'title': 'StBVS'},
+            'principal': {'href': principal_href, 'title': name},
+            'roles': [{'href': f'/api/v3/roles/{r}', 'title': 'Member'} for r in role_ids],
+        },
+    }
+
+
+class TestRoles:
+    async def test_get_roles(
+        self, client: OpenProjectClient, respx_mock: respx.MockRouter
+    ) -> None:
+        respx_mock.get(f'{BASE_URL}/api/v3/roles').mock(
+            return_value=httpx.Response(200, json=_collection([
+                {'_type': 'Role', 'id': 3, 'name': 'Member'},
+                {'_type': 'Role', 'id': 5, 'name': 'Project admin'},
+            ]))
+        )
+        async with client:
+            roles = await client.get_roles()
+        assert [(r.id, r.name) for r in roles] == [(3, 'Member'), (5, 'Project admin')]
+
+
+class TestMemberships:
+    async def test_get_memberships_filters_by_project(
+        self, client: OpenProjectClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get(f'{BASE_URL}/api/v3/memberships').mock(
+            return_value=httpx.Response(200, json=_collection([
+                _membership(2877, '/api/v3/groups/6', 'KB', [3]),
+                _membership(2879, '/api/v3/users/33', 'Grit Keiwel', [3]),
+            ]))
+        )
+        async with client:
+            ms = await client.get_memberships(106)
+        sent = json.loads(route.calls.last.request.url.params['filters'])
+        assert sent == [{'project': {'operator': '=', 'values': ['106']}}]
+        assert [(m.principal_type, m.principal_id) for m in ms] == [('group', 6), ('user', 33)]
+
+    async def test_get_group_members(
+        self, client: OpenProjectClient, respx_mock: respx.MockRouter
+    ) -> None:
+        respx_mock.get(f'{BASE_URL}/api/v3/groups/6').mock(
+            return_value=httpx.Response(200, json={
+                '_type': 'Group', 'id': 6, 'name': 'KB',
+                '_links': {'members': [
+                    {'href': '/api/v3/users/33'}, {'href': '/api/v3/users/34'},
+                ]},
+            })
+        )
+        async with client:
+            members = await client.get_group_members(6)
+        assert members == [33, 34]
+
+    async def test_create_membership_user(
+        self, client: OpenProjectClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.post(f'{BASE_URL}/api/v3/memberships').mock(
+            return_value=httpx.Response(201, json=_membership(99, '/api/v3/users/33', 'Grit', [3]))
+        )
+        async with client:
+            m = await client.create_membership(106, 33, [3])
+        body = json.loads(route.calls.last.request.content)
+        assert body == {'_links': {
+            'project': {'href': '/api/v3/projects/106'},
+            'principal': {'href': '/api/v3/users/33'},
+            'roles': [{'href': '/api/v3/roles/3'}],
+        }}
+        assert m.principal_id == 33
+
+    async def test_create_membership_group_uses_groups_href(
+        self, client: OpenProjectClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.post(f'{BASE_URL}/api/v3/memberships').mock(
+            return_value=httpx.Response(201, json=_membership(98, '/api/v3/groups/6', 'KB', [3]))
+        )
+        async with client:
+            await client.create_membership(106, 6, [3], principal_type='group')
+        body = json.loads(route.calls.last.request.content)
+        assert body['_links']['principal'] == {'href': '/api/v3/groups/6'}
+
+    async def test_update_membership_roles(
+        self, client: OpenProjectClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.patch(f'{BASE_URL}/api/v3/memberships/99').mock(
+            return_value=httpx.Response(200, json=_membership(99, '/api/v3/users/33', 'Grit', [3, 5]))
+        )
+        async with client:
+            m = await client.update_membership_roles(99, [3, 5])
+        body = json.loads(route.calls.last.request.content)
+        assert body == {'_links': {'roles': [
+            {'href': '/api/v3/roles/3'}, {'href': '/api/v3/roles/5'},
+        ]}}
+        assert m.role_ids == [3, 5]

--- a/tests/test_perms_queue.py
+++ b/tests/test_perms_queue.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from op.perms import PendingMembership
+from op.perms_queue import PermissionQueue
+
+
+def test_add_dedups_per_principal_and_unions_roles() -> None:
+    q = PermissionQueue()
+    q.add(PendingMembership(200, 'group', 6, {3}))
+    q.add(PendingMembership(200, 'group', 6, {5}))
+    assert q.count == 1
+    op = q.all()[0]
+    assert op.role_ids == {3, 5}
+
+
+def test_distinct_principals_are_separate() -> None:
+    q = PermissionQueue()
+    q.add_many([
+        PendingMembership(200, 'group', 6, {3}),
+        PendingMembership(200, 'user', 19, {5}),
+        PendingMembership(201, 'group', 6, {3}),
+    ])
+    assert q.count == 3
+
+
+def test_clear_done_keeps_pending() -> None:
+    q = PermissionQueue()
+    q.add(PendingMembership(200, 'group', 6, {3}))
+    q.add(PendingMembership(200, 'user', 19, {5}))
+    ops = q.all()
+    ops[0].status = 'done'
+    q.clear_done()
+    assert q.count == 1
+    assert q.all()[0].principal_id == 19

--- a/tests/test_perms_tui.py
+++ b/tests/test_perms_tui.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import typing as T
+
+import pytest
+
+from op.config import Config, ConnectionConfig, DefaultsConfig, RemoteConfig
+from op.models import Membership, Role
+from op.tui.perms_app import PermsApp
+from op.tui.perms_projects_screen import PermsProjectsScreen
+
+
+def _membership(mid: int, kind: str, pid: int, project: int, roles: list[int]) -> Membership:
+    return Membership(
+        id=mid, project_id=project, principal_id=pid, principal_name=f'p{pid}',
+        principal_type=kind, role_ids=roles,
+    )
+
+
+class FakeClient:
+    """Records create/patch calls; serves a fixed membership/group dataset.
+
+    Projects: 1 "Ober" (parent), 2 "Unter" (child of 1).
+    Project 1 has group KB(6) (members 33,34); project 2 has nothing.
+    """
+
+    def __init__(self) -> None:
+        self.created: list[tuple] = []
+        self.patched: list[tuple] = []
+        self._memberships = {
+            1: [
+                _membership(10, 'group', 6, 1, [3]),
+                _membership(11, 'user', 33, 1, [3]),  # materialised
+                _membership(12, 'user', 34, 1, [3]),  # materialised
+            ],
+            2: [],
+        }
+
+    async def get_roles(self) -> list[Role]:
+        return [Role(id=3, name='Member'), Role(id=5, name='Project admin')]
+
+    async def get_memberships(self, project_id: int) -> list[Membership]:
+        return self._memberships.get(project_id, [])
+
+    async def get_group_members(self, group_id: int) -> list[int]:
+        return [33, 34] if group_id == 6 else []
+
+    async def create_membership(self, project_id, principal_id, role_ids, *, principal_type='user'):  # noqa: ANN001
+        self.created.append((project_id, principal_type, principal_id, tuple(role_ids)))
+        return _membership(99, principal_type, principal_id, project_id, list(role_ids))
+
+    async def update_membership_roles(self, membership_id, role_ids):  # noqa: ANN001
+        self.patched.append((membership_id, tuple(role_ids)))
+        return _membership(membership_id, 'user', 0, 0, list(role_ids))
+
+
+def _config() -> Config:
+    return Config(
+        connection=ConnectionConfig(base_url='https://op.example.com'),
+        defaults=DefaultsConfig(),
+        remote=RemoteConfig(
+            projects={1: 'Ober', 2: 'Unter'},
+            project_parents={2: 1},
+            groups={6: 'KB'},
+            users={33: 'Grit', 34: 'Christian', 19: 'Martin'},
+        ),
+    )
+
+
+@pytest.fixture
+def app_factory() -> T.Callable[..., PermsApp]:
+    def _make(start: int | None = None) -> PermsApp:
+        return PermsApp(config=_config(), client=FakeClient(), start_project=start)
+    return _make
+
+
+class TestProjectsScreen:
+    async def test_loads_and_shows_hierarchy(self, app_factory) -> None:  # noqa: ANN001
+        from textual.widgets import DataTable
+
+        app = app_factory()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.pause()
+            assert app.loaded
+            table = app.screen.query_one('#perms-projects', DataTable)
+            assert table.row_count == 2  # Ober + Unter
+
+    async def test_child_flagged_as_mismatch(self, app_factory) -> None:  # noqa: ANN001
+        app = app_factory()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.pause()
+            screen = app.screen
+            assert isinstance(screen, PermsProjectsScreen)
+            # Unter (2) lacks KB → mismatch flag
+            assert '▲' in str(screen._flag_for(2))
+            # Ober (1) is a root → no flag
+            assert '▲' not in str(screen._flag_for(1))
+
+    async def test_fix_queues_propagation(self, app_factory) -> None:  # noqa: ANN001
+        app = app_factory()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.pause()
+            screen = app.screen
+            screen._move_cursor_to(1)  # Ober
+            await pilot.pause()
+            screen.action_fix()
+            await pilot.pause()
+            # KB group should be queued for project 2
+            ops = app.perms_queue.all()
+            assert any(o.project_id == 2 and o.kind == 'group' and o.principal_id == 6 for o in ops)
+
+
+class TestApply:
+    async def test_apply_creates_missing_group_membership(self, app_factory) -> None:  # noqa: ANN001
+        app = app_factory()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.pause()
+            screen = app.screen
+            screen._move_cursor_to(1)
+            await pilot.pause()
+            screen.action_fix()
+            await pilot.pause()
+            screen.action_review()
+            await pilot.pause()
+            app.screen.action_apply()
+            # let the apply worker run
+            for _ in range(6):
+                await pilot.pause()
+            assert (2, 'group', 6, (3,)) in app.client.created
+
+
+class TestDetailScreen:
+    async def test_detail_folds_group_members(self, app_factory) -> None:  # noqa: ANN001
+        from textual.widgets import DataTable
+        from op.tui.perms_detail_screen import PermsDetailScreen
+
+        app = app_factory()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.pause()
+            app.push_screen(PermsDetailScreen(1))
+            await pilot.pause()
+            table = app.screen.query_one('#perms-detail', DataTable)
+            # 1 group row + 2 folded members = 3 rows (no separate direct-user rows)
+            assert table.row_count == 3


### PR DESCRIPTION
Schließt #19.

Neuer TUI-Modus **`op perms [projekt]`** zum Sichten, Übertragen und Konsistenthalten von OpenProject-Projektberechtigungen.

## Funktionen
- **Gruppen-/benutzer-zentrierte Anzeige:** Da die v3-API keinen `inherited_from`-Marker liefert, wird das **Source-Set** mengenbasiert rekonstruiert (`perms.build_source_set`) — Gruppen + echte Direkt-User; via Gruppe sichtbare User werden unter der Gruppe eingeklappt (keine transitiven Einzelzeilen).
- **Übertragen** (`c`): additiver Transfer der Berechtigungen eines anderen Projekts.
- **Hierarchie-Check + Korrektur** (`f`): Projektbaum markiert Abweichungen zum Oberprojekt (`▲`); ein Keystroke gleicht den **gesamten Teilbaum** rekursiv an (`plan_propagation`). Additiv — es wird nie etwas entfernt.
- **Sammeln → Review → Apply:** geplante Mitgliedschaften werden in einer `PermissionQueue` gesammelt, per `g` reviewed und angewendet (`create_membership` / `update_membership_roles`).
- Mitgliedschaften werden **live** geladen (nicht aus dem `[remote.*]`-Cache).

## Umfang
- Modelle `Role`, `Membership`, `Group.member_ids`
- API: `get_roles`, `get_memberships`, `get_group_members`, `create_membership`, `update_membership_roles`
- Reine Logik in `perms.py` + `perms_queue.py`
- `PermsApp` + Projektbaum/Detail/Review/Applying-Screens
- CLI-Einstieg `op perms`, Doku in CLAUDE.md

## Tests
574 Tests grün (neue: `test_perms.py`, `test_perms_api.py`, `test_perms_queue.py`, `test_perms_tui.py`, erweitertes `test_models.py`). Source-Set-Rekonstruktion zusätzlich live gegen StBVS verifiziert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)